### PR TITLE
Improve unit tests

### DIFF
--- a/src/test/java/com/mariadesk/api/responses/IVRTest.java
+++ b/src/test/java/com/mariadesk/api/responses/IVRTest.java
@@ -1,25 +1,26 @@
 package com.mariadesk.api.responses;
 
+import com.twilio.twiml.TwiMLException;
 import org.junit.Test;
 
 public class IVRTest extends ResponseTest {
     private String agentNumber = "+35191000000000";
 
     @Test
-    public void testRedirectToQuestionsResponse() {
+    public void testRedirectToQuestionsResponse() throws Exception {
         String expectedXML = "<Response><Redirect>/voice/questions</Redirect></Response>";
         assertIVRResponse("1", expectedXML);
     }
 
     @Test
-    public void testDialAgentResponse() {
+    public void testDialAgentResponse() throws Exception {
         String expectedXML = "<Response><Dial><Number>" + agentNumber + "</Number></Dial></Response>";
         assertIVRResponse("2", expectedXML);
 
     }
 
     @Test
-    public void testRedirectToInboundResponse() {
+    public void testRedirectToInboundResponse() throws Exception {
         String expectedXML = "<Response><Redirect>/voice/inbound</Redirect></Response>";
 
         String emptyDigits = "";
@@ -29,7 +30,7 @@ public class IVRTest extends ResponseTest {
         assertIVRResponse(outOfRangeDigit, expectedXML);
     }
 
-    public void assertIVRResponse(String digits, String expectedXML) {
+    public void assertIVRResponse(String digits, String expectedXML) throws TwiMLException {
         IVR ivr = new IVR(digits, agentNumber);
         assertResponse(ivr, expectedXML);
     }

--- a/src/test/java/com/mariadesk/api/responses/InboundTest.java
+++ b/src/test/java/com/mariadesk/api/responses/InboundTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 public class InboundTest extends ResponseTest {
   @Test
-  public void testResponse() {
+  public void testResponse() throws Exception {
     Inbound inbound = new Inbound();
     String expectedXML = "<Response><Say>Dear customer thanks for calling Maria Flower Shop</Say><Gather "
                        + "numDigits=\"1\" action=\"/voice/ivr\"><Say>For questions press 1, to talk with an "

--- a/src/test/java/com/mariadesk/api/responses/QuestionsTest.java
+++ b/src/test/java/com/mariadesk/api/responses/QuestionsTest.java
@@ -1,11 +1,12 @@
 package com.mariadesk.api.responses;
 
+import com.twilio.twiml.TwiMLException;
 import org.junit.Test;
 
 public class QuestionsTest extends ResponseTest {
 
     @Test
-    public void testQuestionsResponse() {
+    public void testQuestionsResponse() throws Exception {
         String expectedXML = "<Response><Gather numDigits=\"1\" action=\"/voice/questions\"><Say>For payments press 1,"
                            + " for orders press 2,for email support press 3</Say></Gather></Response>";
 
@@ -17,27 +18,28 @@ public class QuestionsTest extends ResponseTest {
     }
 
     @Test
-    public void testPaymentAnswerResponse() {
+    public void testPaymentAnswerResponse() throws Exception {
         String expectedXML = "<Response><Say>Use IBAN NL22ABNA0566397423 and send payment proofs to payments at "
                            + "mariaflowershop dot pt</Say></Response>";
         assertQuestionsResponse("1", expectedXML);
     }
 
     @Test
-    public void testOrdersAnswerResponse() {
+    public void testOrdersAnswerResponse() throws Exception {
         String expectedXML = "<Response><Say>Place your orders in our online shop at mariaflowershop dot pt</Say>"
                            + "</Response>";
         assertQuestionsResponse("2", expectedXML);
     }
 
     @Test
-    public void testSupportAnswerResponse() {
+    public void testSupportAnswerResponse() throws Exception {
         String expectedXML = "<Response><Say>When you need support, send an email to support at mariaflowershop dot "
                            + "pt</Say></Response>";
         assertQuestionsResponse("3", expectedXML);
     }
 
-    protected void assertQuestionsResponse(String digits, String expectedXML) {
+    protected void assertQuestionsResponse(String digits, String expectedXML)
+      throws TwiMLException {
         Questions questions = new Questions(digits);
         assertResponse(questions, expectedXML);
     }

--- a/src/test/java/com/mariadesk/api/responses/ResponseTest.java
+++ b/src/test/java/com/mariadesk/api/responses/ResponseTest.java
@@ -5,14 +5,8 @@ import com.twilio.twiml.TwiMLException;
 import static org.junit.Assert.assertEquals;
 
 public class ResponseTest {
-    protected void assertResponse(Response response, String expectedXML) {
-
-        try {
-            String xml = response.response().toXml();
-            assertEquals(expectedXML, xml);
-        }
-        catch (TwiMLException e) {
-            e.printStackTrace();
-        }
+    protected void assertResponse(Response response, String expectedXML) throws TwiMLException {
+        String xml = response.response().toXml();
+        assertEquals(expectedXML, xml);
     }
 }


### PR DESCRIPTION
This change performs some minor improvements on the project's unit
tests. The idea is to have exceptions thrown up to the test methods
level, and let the testing framework deal with them. Test frameworks
already relate uncaught exceptions as failures. With this change, users
should be more aware of errors in tests, the code is simpler, and
exceptions are not _swallowed_.