### PR TITLE
Allows configuration of skeleton output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It's highly recommended that you use a Java IDE such as [Intellij IDEA (Communit
 ## Clone this Repository
 Once git is installed on your computer you may clone this repository,
 
-    git clone https://github.com/Talkdesk/call-center-challenge.git
+    git clone https://github.com/Talkdesk/call-center-challenge-skeleton.git
 
 and create a local branch for development.
 


### PR DESCRIPTION
Add option `--output` to specify a different output directory. These changes also improve the cleanup of the output directory, not removing `.git` directory, to simplify tracking changes on the skeleton
repository.

Example of usage:
```bash
./skeleton.rb --output ~/dev/call-center-challenge-skeleton
```